### PR TITLE
Update tsconfig.json to use "react-jsx" for JSX.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This allows React to be used within JSX files without having to import it directly. This has been possible since v17.

Without it, opening this repo in an editor with TS typechecking available shows a lot of red lines.

![CleanShot from Jack Weatherilt 2023-12-04 at 06 54 11](https://github.com/medplum/medplum-hello-world/assets/11884004/f5cc0aa8-2c32-4fcd-bff2-5883905c0740)
